### PR TITLE
Use aussrc prefect

### DIFF
--- a/automation/README
+++ b/automation/README
@@ -2,4 +2,4 @@
 2. Enter ausSRC database details in the .env file. 
 3. Enter Google spreadsheet token
 4. Update Google spreadsheet file locations (only if the files are different, e.g. for testing)
-
+5. Update PREFECT_API_URL and PREFECT_API_AUTH_STRING with ausSRC details (ask an ausSRC personnel!)

--- a/automation/config.env.example
+++ b/automation/config.env.example
@@ -5,4 +5,5 @@ DATABASE_USER=
 DATABASE_PASSWORD=
 POSSUM_STATUS_TOKEN=/arc/home/ErikOsinga/.ssh/psm_gspread_token.json
 POSSUM_STATUS_SHEET=https://docs.google.com/spreadsheets/d/1sWCtxSSzTwjYjhxr1_KVLWG2AnrHwSJf_RWQow7wbH0
-PREFECT_API_URL="http://localhost:4200/api"
+PREFECT_API_URL=
+PREFECT_API_AUTH_STRING=

--- a/cirada_software/3d_pipeline_tile_download_ingest.sh
+++ b/cirada_software/3d_pipeline_tile_download_ingest.sh
@@ -8,8 +8,10 @@ p1user=$1
 echo "Opening SSH tunnel to prefect server host (p1) as $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 # Run possum_run_remote to download and ingest tiles
 cd /arc/projects/CIRADA/polarimetry/software/POSSUMutils

--- a/cirada_software/3dpipeline_downloadscript.sh
+++ b/cirada_software/3dpipeline_downloadscript.sh
@@ -7,8 +7,10 @@ echo " this script is deprecated, see 3d_pipeline_tile_download_ingest.sh instea
 # echo "Opening SSH tunnel to prefect server host (p1) as user $1"
 # # open connection
 # ssh -fNT -L 4200:localhost:4200 $1@206.12.93.32
-# # set which port to communicate results to 
-# export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+# set -a
+# source automation/config.env
+# set +a
 
 # #RMtools not used but cant hurt to add it to path
 # echo "TEMPORARILY: adding RMtools[dev] to pythonpath until new release (>v1.4.6)"

--- a/cirada_software/collate_1Dpipeline_PartialTiles.sh
+++ b/cirada_software/collate_1Dpipeline_PartialTiles.sh
@@ -7,8 +7,10 @@ p1user=$2
 echo "Opening SSH tunnel to prefect server host (p1) as user $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 
 # for band 1, directory is also "943MHz"

--- a/cirada_software/create_symlinks.sh
+++ b/cirada_software/create_symlinks.sh
@@ -9,8 +9,10 @@ p1user=$1
 echo "Opening SSH tunnel to prefect server host (p1) as $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 # Create symbolic links from the timeblocked directories in the tiledir
 python -m cirada_software.create_symlinks --tiledir /arc/projects/CIRADA/polarimetry/ASKAP/Tiles

--- a/cirada_software/downloadscript.sh
+++ b/cirada_software/downloadscript.sh
@@ -7,8 +7,10 @@ echo "This file is DEPRECATED"
 # echo "Opening SSH tunnel to prefect server host (p1)"
 # # open connection
 # ssh -fNT -L 4200:localhost:4200 erik@206.12.93.32
-# # set which port to communicate results to 
-# export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+# set -a
+# source automation/config.env
+# set +a
 
 # #RMtools not used but cant hurt to add it to path
 # echo "TEMPORARILY: adding RMtools[dev] to pythonpath until new release (>v1.4.6)"

--- a/cirada_software/ingest_3Dpipeline_band1_prefect.sh
+++ b/cirada_software/ingest_3Dpipeline_band1_prefect.sh
@@ -5,8 +5,10 @@ p1user=$3
 echo "Opening SSH tunnel to prefect server host (p1) as user $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 #RMtools not used but cant hurt to add it to path
 echo "TEMPORARILY: adding RMtools[dev] to pythonpath until new release (>v1.4.6)"

--- a/cirada_software/run_1Dpipeline_PartialTiles_band1.sh
+++ b/cirada_software/run_1Dpipeline_PartialTiles_band1.sh
@@ -35,8 +35,10 @@ python /arc/projects/CIRADA/polarimetry/software/POSSUMutils/cirada_software/cre
 echo "Opening SSH tunnel to prefect server host (p1) as user $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 echo "adding RMtools[dev] to pythonpath to work with dev branch of RMtools"
 export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"

--- a/cirada_software/run_1Dpipeline_PartialTiles_band1_srl_and_googlesheet.sh
+++ b/cirada_software/run_1Dpipeline_PartialTiles_band1_srl_and_googlesheet.sh
@@ -15,9 +15,10 @@ python /arc/projects/CIRADA/polarimetry/software/POSSUMutils/cirada_software/cre
 echo "Opening SSH tunnel to prefect server host (p1) as user $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
-
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 echo "adding RMtools[dev] to pythonpath to work with dev branch of RMtools"
 export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"
 

--- a/cirada_software/run_1Dpipeline_PartialTiles_band1_summary.sh
+++ b/cirada_software/run_1Dpipeline_PartialTiles_band1_summary.sh
@@ -16,8 +16,10 @@ python /arc/projects/CIRADA/polarimetry/software/POSSUMutils/cirada_software/cre
 echo "Opening SSH tunnel to prefect server host (p1) as user $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 echo "adding RMtools[dev] to pythonpath to work with dev branch of RMtools"
 export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"

--- a/cirada_software/run_3Dpipeline_band1_prefect.sh
+++ b/cirada_software/run_3Dpipeline_band1_prefect.sh
@@ -13,8 +13,10 @@ p1user=$3
 echo "Opening SSH tunnel to prefect server host (p1) as user $p1user"
 # open connection
 ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# set PREFECT URL
+set -a
+source automation/config.env
+set +a
 
 echo "TEMPORARILY: adding RMtools[dev] to pythonpath until new release (>v1.4.6)"
 export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"

--- a/cirada_software/test_3dpipeline_job.sh
+++ b/cirada_software/test_3dpipeline_job.sh
@@ -1,26 +1,27 @@
 
 
-echo "Preparing test pipeline run"
-testdir=/arc/projects/CIRADA/polarimetry/pipeline_runs/943MHz/TEST_11224
-echo "Will be run in $testdir"
+# echo "Preparing test pipeline run"
+# testdir=/arc/projects/CIRADA/polarimetry/pipeline_runs/943MHz/TEST_11224
+# echo "Will be run in $testdir"
 
-p1user=$1
+# p1user=$1
 
-echo "Opening SSH tunnel to prefect server host (p1) as $p1user"
-# open connection
-ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
-# set which port to communicate results to 
-export PREFECT_API_URL="http://localhost:4200/api"
+# echo "Opening SSH tunnel to prefect server host (p1) as $p1user"
+# # open connection
+# ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
+# set PREFECT URL 
+set -a
+source automation/config.env
+set +a
+
+# echo "Adding RMtools[dev] to pythonpath"
+# export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"
 
 
-echo "Adding RMtools[dev] to pythonpath"
-export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"
+# pipeline=/arc/projects/CIRADA/polarimetry/software/POSSUM_Polarimetry_Pipeline/pipeline/pipeline_prefect.py
+# # Start actual pipeline with psrecord
+# psrecord "python $pipeline $testdir/config_11224_zoom_test_all_modules.ini test3d" --include-children --log $testdir/psrecord_test_$p1user.txt --plot $testdir/psrecord_test_$p1user.png --interval 1
 
-
-pipeline=/arc/projects/CIRADA/polarimetry/software/POSSUM_Polarimetry_Pipeline/pipeline/pipeline_prefect.py
-# Start actual pipeline with psrecord
-psrecord "python $pipeline $testdir/config_11224_zoom_test_all_modules.ini test3d" --include-children --log $testdir/psrecord_test_$p1user.txt --plot $testdir/psrecord_test_$p1user.png --interval 1
-
-# Check database access, will report to dashboard as flow "test_db_access"
-cd /arc/projects/CIRADA/polarimetry/software/POSSUMutils
+# # Check database access, will report to dashboard as flow "test_db_access"
+# cd /arc/projects/CIRADA/polarimetry/software/POSSUMutils
 python -m possum_pipeline_control.test_database_access --run_as_flow

--- a/cirada_software/test_3dpipeline_job.sh
+++ b/cirada_software/test_3dpipeline_job.sh
@@ -1,27 +1,27 @@
 
 
-# echo "Preparing test pipeline run"
-# testdir=/arc/projects/CIRADA/polarimetry/pipeline_runs/943MHz/TEST_11224
-# echo "Will be run in $testdir"
+echo "Preparing test pipeline run"
+testdir=/arc/projects/CIRADA/polarimetry/pipeline_runs/943MHz/TEST_11224
+echo "Will be run in $testdir"
 
-# p1user=$1
+p1user=$1
 
-# echo "Opening SSH tunnel to prefect server host (p1) as $p1user"
-# # open connection
-# ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
+echo "Opening SSH tunnel to prefect server host (p1) as $p1user"
+# open connection
+ssh -fNT -L 4200:localhost:4200 $p1user@206.12.93.32
 # set PREFECT URL 
 set -a
 source automation/config.env
 set +a
 
-# echo "Adding RMtools[dev] to pythonpath"
-# export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"
+echo "Adding RMtools[dev] to pythonpath"
+export PYTHONPATH="/arc/projects/CIRADA/polarimetry/software/RMtoolsdev/:$PYTHONPATH"
 
 
-# pipeline=/arc/projects/CIRADA/polarimetry/software/POSSUM_Polarimetry_Pipeline/pipeline/pipeline_prefect.py
-# # Start actual pipeline with psrecord
-# psrecord "python $pipeline $testdir/config_11224_zoom_test_all_modules.ini test3d" --include-children --log $testdir/psrecord_test_$p1user.txt --plot $testdir/psrecord_test_$p1user.png --interval 1
+pipeline=/arc/projects/CIRADA/polarimetry/software/POSSUM_Polarimetry_Pipeline/pipeline/pipeline_prefect.py
+# Start actual pipeline with psrecord
+psrecord "python $pipeline $testdir/config_11224_zoom_test_all_modules.ini test3d" --include-children --log $testdir/psrecord_test_$p1user.txt --plot $testdir/psrecord_test_$p1user.png --interval 1
 
-# # Check database access, will report to dashboard as flow "test_db_access"
-# cd /arc/projects/CIRADA/polarimetry/software/POSSUMutils
+# Check database access, will report to dashboard as flow "test_db_access"
+cd /arc/projects/CIRADA/polarimetry/software/POSSUMutils
 python -m possum_pipeline_control.test_database_access --run_as_flow


### PR DESCRIPTION
* Instead of hardcoding localhost for Prefect URL, we provide it in the config.env file.

* PREFECT_API_URL and PREFECT_API_AUTH_STRING must be exported into the environment variables before executing the flows. I tried doing this by running load_dotenv in the python scripts before executing the flows, but somehow it does not work (I might've missed something stupid.. it is the new year). So I did it in the shell script by calling source env instead. If you think using load_dotenv is cleaner, we could look into this further.

* I tested this by running cirada_software/test_3dpipeline_job.sh (with some stuff commented out to avoid earlier failures). 

* You can see the runs made it to the Prefect server (possum-prefect.aussrc.org): 
<img width="811" height="507" alt="Screenshot 2026-01-07 at 12 58 13 PM" src="https://github.com/user-attachments/assets/e02ec7b2-74d3-433a-bd8c-a6626fc15037" />


