### PR TITLE
Make sure to pass on prefect IP address to canfar

### DIFF
--- a/possum_pipeline_control/check_ingest_3Dpipeline.py
+++ b/possum_pipeline_control/check_ingest_3Dpipeline.py
@@ -89,7 +89,7 @@ def launch_ingest(tilenumber, band):
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )

--- a/possum_pipeline_control/check_status_and_launch_3Dpipeline_v2.py
+++ b/possum_pipeline_control/check_status_and_launch_3Dpipeline_v2.py
@@ -275,7 +275,7 @@ def launch_download_session(jobname="3dtile-dl"):
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )
@@ -314,7 +314,7 @@ def launch_create_symlinks(jobname="3dsymlinks"):
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )

--- a/possum_pipeline_control/launch_1Dpipeline_PartialTiles_band1.py
+++ b/possum_pipeline_control/launch_1Dpipeline_PartialTiles_band1.py
@@ -47,7 +47,7 @@ def launch_session(run_name, field_ID, tilenumbers, SBnumber, image, cores, ram)
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )

--- a/possum_pipeline_control/launch_1Dpipeline_PartialTiles_band1_pre_or_post.py
+++ b/possum_pipeline_control/launch_1Dpipeline_PartialTiles_band1_pre_or_post.py
@@ -80,7 +80,7 @@ def launch_session(
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )

--- a/possum_pipeline_control/launch_3Dpipeline_band1.py
+++ b/possum_pipeline_control/launch_3Dpipeline_band1.py
@@ -30,7 +30,7 @@ def launch_session(run_name, tilenumber, image, cores, ram):
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )

--- a/possum_pipeline_control/submit_download.py
+++ b/possum_pipeline_control/submit_download.py
@@ -55,7 +55,7 @@ def launch_download():
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )

--- a/possum_pipeline_control/update_partialtile_google_sheet.py
+++ b/possum_pipeline_control/update_partialtile_google_sheet.py
@@ -490,7 +490,7 @@ def launch_collate_job():
         args=args,
         replicas=1,
         env={
-            "PREFECT_API_URL": os.getenv('PREFECT_API_URL'),
+            "PREFECT_API_URL": os.getenv('PREFECT_SERVER_IP'),
             "PREFECT_API_AUTH_STRING": os.getenv('PREFECT_API_AUTH_STRING')
         },
     )


### PR DESCRIPTION
A quick hack to make sure the actual IP address is passed on instead of http://prefect-server:4200/api from docker compose. I added a custom environment variable called PREFECT_SERVER_IP in docker compose for this purpose.