### PR TITLE
fix copying backup to canfar

### DIFF
--- a/possum_pipeline_control/check_status_and_launch_3Dpipeline_v2.py
+++ b/possum_pipeline_control/check_status_and_launch_3Dpipeline_v2.py
@@ -483,7 +483,8 @@ def run_prefect_db_backup():
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
     OUTDIR = Path.home() / "prefect-backups"
     OUTDIR.mkdir(parents=True, exist_ok=True)
-    db_backup = OUTDIR / f"prefect-{ts}.sql"
+    db_file_name = f"prefect-{ts}.sql"
+    db_backup = OUTDIR / db_file_name
     
     cmd = ["bash", bkpscript, str(db_backup)]
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -503,9 +504,14 @@ def run_prefect_db_backup():
         )
     # --- Copy to CANFAR ---
     print("Copying the backup to CANFAR...")
-    client = Client()
-    client.copy(str(db_backup), "arc:projects/CIRADA/polarimetry/software/prefect-backups")
-    print("Backup completed successfully")    
+    try:
+        client = Client()
+        VOS_FOLDER = "arc:projects/CIRADA/polarimetry/software/prefect-backups"
+        remote_file = f"{VOS_FOLDER}/{db_file_name}"
+        client.copy(str(db_backup), remote_file)
+        print("Backup completed successfully")    
+    except Exception as e:
+        print(f"Failed to copy backup to CANFAR: {e}")  
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Reopen PR to fix up database file upload. 
Screenshot below to see that it works (the last 2 files at the bottom were successfully uploaded):
<img width="1676" height="476" alt="Screenshot 2026-04-30 at 6 44 18 PM" src="https://github.com/user-attachments/assets/114bf25b-b92e-4102-a793-83eccfcf1a97" />

This will fix this error when it tries to upload database backup every 2 weeks:

OSError: [Errno 14]
01:27:32 PM
prefect.flow_runs
vos://cadc.nrc.ca!arc/projects/CIRADA/polarimetry/software/prefect-backups:
01:27:32 PM
prefect.flow_runs
InvalidArgument: transfer destination is not a data node
****
Copying the backup to CANFAR...
01:27:32 PM
prefect.flow_runs
Error occurred while running the script: Command '['python', '-m', 'possum_pipeline_control.check_status_and_launch_3Dpipeline_v2']' returned non-zero exit status 1.
01:27:32 PM
prefect.flow_runs
Encountered exception during execution: CalledProcessError(1, ['python', '-m', 'possum_pipeline_control.check_status_and_launch_3Dpipeline_v2'])
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/prefect/flow_engine.py", line 788, in run_context
    yield self
  File "/usr/local/lib/python3.12/site-packages/prefect/flow_engine.py", line 1409, in run_flow_sync
    engine.call_flow_fn()
  File "/usr/local/lib/python3.12/site-packages/prefect/flow_engine.py", line 808, in call_flow_fn
    result = call_with_parameters(self.flow.fn, self.parameters)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/prefect/utilities/callables.py", line 210, in call_with_parameters
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpb6nk_gowprefect/POSSUMutils-main/possum_pipeline_control/control_3D_pipeline.py", line 235, in main_flow
    run_script_intermittently(
  File "/tmp/tmpb6nk_gowprefect/POSSUMutils-main/possum_pipeline_control/control_3D_pipeline.py", line 203, in run_script_intermittently
    util.print_subprocess_output(process, command)
  File "/tmp/tmpb6nk_gowprefect/POSSUMutils-main/possum_pipeline_control/util.py", line 199, in print_subprocess_output
    raise subprocess.CalledProcessError(return_code, command)
subprocess.CalledProcessError: Command '['python', '-m', 'possum_pipeline_control.check_status_and_launch_3Dpipeline_v2']' returned non-zero exit status 1.
01:27:32 PM
prefect.flow_runs
Finished in state Failed("Flow run encountered an exception: CalledProcessError: Command '['python', '-m', 'possum_pipeline_control.check_status_and_launch_3Dpipeline_v2']' returned non-zero exit status 1.")